### PR TITLE
Fix UTF-8 Encoding

### DIFF
--- a/Importers/M3U.py
+++ b/Importers/M3U.py
@@ -6,7 +6,7 @@ def _ImportMe(PlaylistPath):
     PlaylistFiles=[]
     PlaylistDirPath=os.path.dirname(PlaylistPath)+os.sep
     try:
-        with open(PlaylistPath, 'r') as PlaylistFileHandle:
+        with open(PlaylistPath, 'r', encoding='utf-8') as PlaylistFileHandle: #Specify UTF-8 here to avoid Unicode errors
             for LineStr in PlaylistFileHandle:
                 if(LineStr[0]=='#'): #Ignore comments/controls
                     continue


### PR DESCRIPTION
By specifying UTF-8 here in the encoder, you don't have to set an environment variable, which solves problems in windows without having to change your system locale or reconfigure cygwin packages.
