### PR TITLE
Use `os.path` functions to support all platforms.

### DIFF
--- a/Importers/M3U.py
+++ b/Importers/M3U.py
@@ -9,6 +9,10 @@ def _ImportMe(PlaylistPath):
                 if(LineStr[0]=='#'): #Ignore comments/controls
                     continue
                 LookupPath = LineStr.strip()
+                if(not os.path.isabs(LookupPath)):
+                    # convert to absolute path
+                    PlaylistDir = os.path.dirname(PlaylistPath)
+                    LookupPath = os.path.abspath(os.path.join(PlaylistDir, LookupPath))
                 if(not os.path.isfile(LookupPath)): #Confirm file exists
                     raise Exception('PlaylistFileNotFound', LineStr)
                 PlaylistFiles.append(LookupPath) #Add the relative path to the playlist file list

--- a/Importers/M3U.py
+++ b/Importers/M3U.py
@@ -1,17 +1,14 @@
 import Importers
 import os
-import re
 
 def _ImportMe(PlaylistPath):
     PlaylistFiles=[]
-    PlaylistDirPath=os.path.dirname(PlaylistPath)+os.sep
     try:
         with open(PlaylistPath, 'r', encoding='utf-8') as PlaylistFileHandle: #Specify UTF-8 here to avoid Unicode errors
             for LineStr in PlaylistFileHandle:
                 if(LineStr[0]=='#'): #Ignore comments/controls
                     continue
-                IsAbsolutePath=(LineStr[0:2]=='\\\\' or re.match('[a-z]:\\\\', LineStr, flags=re.I)) #Check for absolute path syntax (smb or drive letter)
-                LookupPath=os.path.realpath(('' if IsAbsolutePath else PlaylistDirPath)+LineStr.rstrip('\n'))
+                LookupPath = LineStr.strip()
                 if(not os.path.isfile(LookupPath)): #Confirm file exists
                     raise Exception('PlaylistFileNotFound', LineStr)
                 PlaylistFiles.append(LookupPath) #Add the relative path to the playlist file list


### PR DESCRIPTION
Instead of using `\\` assumptions, use `os.path` functions, which take care of the platform differences.

Tested on Linux on a playlist with relative and absolute paths. Not tested on Windows.
